### PR TITLE
updated docs for 8.9.1 node and caution node for newer versions until…

### DIFF
--- a/docs/stake-pool-guides/docker-pool-guide.md
+++ b/docs/stake-pool-guides/docker-pool-guide.md
@@ -46,6 +46,12 @@ sudo mkdir -p node/db && sudo mkdir -p node/files && sudo mkdir -p dockerfiles/f
 
 The files to build the docker images will be downloaded from [MINI1 pool GitHub](https://github.com/jterrier84/Cardano-node-docker)
 
+:::caution
+
+⚠️ If there's a newer version of the cardano-node released, you may have to fork and manually update jterrier84's Cardano-node-docker repo (build.sh and run.sh files) -- Or open an Issue.
+
+:::
+
 ```bash title=">_ Terminal"
 cd dockerfiles
 sudo wget -N https://raw.githubusercontent.com/jterrier84/Cardano-node-docker/master/dockerfiles/armada-cn-arm64.dockerfile
@@ -121,7 +127,7 @@ Either way, the docker image includes:
 Pull the image with:
 
 ```bash
-docker pull armadaalliance/armada-cn:8.7.2
+docker pull armadaalliance/armada-cn:8.9.1
 ```
 
 You should see your Cardano node docker image in the list:
@@ -132,7 +138,7 @@ docker images
 
 ```bash
 REPOSITORY              TAG            IMAGE ID       CREATED          SIZE
-armadaalliance/armada-cn        8.7.2         da4414775ce6   37 seconds ago   700MB
+armadaalliance/armada-cn        8.9.1         da4414775ce6   37 seconds ago   700MB
 ```
 
 You can now proceed with chapter 4, in order to start the node.
@@ -155,7 +161,7 @@ You should see your Cardano node docker image in the list, e.g.
 
 ```bash title=">_ Terminal"
 REPOSITORY              TAG            IMAGE ID       CREATED          SIZE
-armadaalliance/armada-cn        8.7.2         da4414775ce6   37 seconds ago   700MB
+armadaalliance/armada-cn        8.9.1         da4414775ce6   37 seconds ago   700MB
 <none>                  <none>         f3891eef21e4   3 minutes ago    1.09GB
 ```
 
@@ -191,7 +197,7 @@ Important: Change the directory paths CN_CONFIG_PATH and CN_DB_PATH to the corre
 ```bash title=">_ Terminal"
 ##Configuration for relay and block producing node
 CNIMAGENAME="armada/armada-cn"                                   ## Name of the Cardano docker image
-CNVERSION="8.7.2"                                                ## Version of the cardano-node. It must match with the version of the docker i>
+CNVERSION="8.9.1"                                                ## Version of the cardano-node. It must match with the version of the docker i>
 CNNETWORK="preprod"                                              ## Use "mainnet" if connecting node to the mainnet
 CNMODE="relay"                                                   ## Use "bp" if you configure the node as block production node
 CNPORT="3001"                                                    ## Define the port of the node
@@ -228,7 +234,7 @@ If the docker node started successfully, you might see something like this:
 
 ```bash title=">_ Terminal"
 CONTAINER ID   IMAGE                     COMMAND                  CREATED          STATUS                    PORTS                                                                                      NAMES
-fed0cfbf7d86   armadaalliance/armada-cn:8.7.2   "bash title=">_ Terminal" -c /home/carda…"   12 seconds ago   Up 10 seconds (healthy)   0.0.0.0:3001->3001/tcp, :::3001->3001/tcp, 0.0.0.0:12799->12798/tcp, :::12799->12798/tcp   cardano-node-testnet-1.34.1
+fed0cfbf7d86   armadaalliance/armada-cn:8.9.1   "bash title=">_ Terminal" -c /home/carda…"   12 seconds ago   Up 10 seconds (healthy)   0.0.0.0:3001->3001/tcp, :::3001->3001/tcp, 0.0.0.0:12799->12798/tcp, :::12799->12798/tcp   cardano-node-testnet-1.34.1
 ```
 
 You can also check the logs of the running cardano-node:


### PR DESCRIPTION
Updates for Cardano Node Docker Image for ARM64 devices 🐳
- from cardano-node 8.7.2 to 8.9.1
- added caution statement to check for newer node